### PR TITLE
fix: select & highlight locked node when triggering context menu

### DIFF
--- a/packages/webcomponents/src/spectrum/context-menu.ts
+++ b/packages/webcomponents/src/spectrum/context-menu.ts
@@ -466,8 +466,10 @@ export class ContextMenu extends LitElement {
     const nodes = this.api.elementsFromBBox(cx, cy, cx, cy, false).filter((node) => !node.has(UI));
     if (nodes.length > 0) {
       const node = this.api.getNodeByEntity(nodes[0]);
-      this.api.selectNodes([node]);
-      this.api.highlightNodes([node]);
+      if (node) {
+        this.api.selectNodes([node]);
+        this.api.highlightNodes([node]);
+      }
     }
 
     const trigger = event.target as LitElement;

--- a/packages/webcomponents/src/spectrum/context-menu.ts
+++ b/packages/webcomponents/src/spectrum/context-menu.ts
@@ -460,6 +460,16 @@ export class ContextMenu extends LitElement {
 
     this.lastContextMenuPosition = { x: event.clientX, y: event.clientY };
 
+    // Select the node first.
+    const { x: vx, y: vy } = this.api.client2Viewport(this.lastContextMenuPosition);
+    const { x: cx, y: cy } = this.api.viewport2Canvas({ x: vx, y: vy });
+    const nodes = this.api.elementsFromBBox(cx, cy, cx, cy, false).filter((node) => !node.has(UI));
+    if (nodes.length > 0) {
+      const node = this.api.getNodeByEntity(nodes[0]);
+      this.api.selectNodes([node]);
+      this.api.highlightNodes([node]);
+    }
+
     const trigger = event.target as LitElement;
     const virtualTrigger = new VirtualTrigger(
       this.lastContextMenuPosition.x,


### PR DESCRIPTION
#105 

<img width="606" height="586" alt="image" src="https://github.com/user-attachments/assets/faf13cb0-0bde-4fcb-a65b-546cd9beeb00" />